### PR TITLE
Fix cache file path trailing slash

### DIFF
--- a/src/Devitek/Core/Translation/YamlFileLoader.php
+++ b/src/Devitek/Core/Translation/YamlFileLoader.php
@@ -144,7 +144,7 @@ class YamlFileLoader implements LoaderInterface
 
 		$cachedir = storage_path() . '/yaml-translation/';
 	        
-	    $cachefile = $cachedir . '/cache.' . md5($file) . '.php';
+	    $cachefile = $cachedir . 'cache.' . md5($file) . '.php';
 
         if (@filemtime($cachefile) < filemtime($file)) {
 	        


### PR DESCRIPTION
The trailing slash is already in the `$cachedir` variable.