### PR TITLE
add support for Laravel 5.4

### DIFF
--- a/src/Devitek/Core/Translation/YamlFileLoader.php
+++ b/src/Devitek/Core/Translation/YamlFileLoader.php
@@ -214,4 +214,14 @@ class YamlFileLoader implements LoaderInterface
         $this->hints[$namespace] = $hint;
     }
 
+
+    /**
+     * Get an array of all the registered namespaces.
+     *
+     * @return array
+     */
+    public function namespaces()
+    {
+        return $this->hints;
+    }
 }


### PR DESCRIPTION
In Laravel 5.4 a new method was added to
Illuminate\Translation\LoaderInterface which had to be implemented by
the YamlFileLoader.