### PR TITLE
Optional Arr:dot() usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ This package uses Symfony/Yaml parser.
 
 Add ```"devitek/yaml-translation": "4.*"``` to your **composer.json** by running :
 
-    php composer.phar require devitek/yaml-translation
+    composer require devitek/yaml-translation
 
-And select version : ```4.*```
+And select version: ```4.*```
+
+Finally, publish all vendor assets to create a `yaml-translation.php`: 
+
+`php artisan vendor:publish`
+
 
 ## Add support in Laravel
 

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,12 @@
             "Devitek\\": "src/Devitek"
         }
     },
+    "extra": {
+        "laravel": {
+          "providers": [
+            "Devitek\\Core\\Translation\\TranslationServiceProvider"
+          ]
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/src/Devitek/Core/Translation/TranslationServiceProvider.php
+++ b/src/Devitek/Core/Translation/TranslationServiceProvider.php
@@ -2,28 +2,32 @@
 
 namespace Devitek\Core\Translation;
 
-use Illuminate\Translation\TranslationServiceProvider as IlluminateTranslationServiceProvider;
-
-class TranslationServiceProvider extends IlluminateTranslationServiceProvider
+class TranslationServiceProvider extends \Illuminate\Translation\TranslationServiceProvider
 {
     /**
      * @return void
      */
     public function boot()
     {
-        $this->publishes([
-            __DIR__ . '/../../../config/yaml-translation.php' => config_path('yaml-translation.php', 'yaml-translation'),
-        ]);
+        $this->setupConfig();
     }
 
     /**
+     * Setup the config.
+     *
      * @return void
      */
-    public function register()
+    protected function setupConfig()
     {
-        $this->mergeConfigFrom(
-            __DIR__ . '/../../../config/yaml-translation.php', 'yaml-translation'
-        );
+        $source = realpath(__DIR__ . '/../../../config/yaml-translation.php');
+
+        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+            $this->publishes([$source => config_path('yaml-translation.php')]);
+        } elseif ($this->app instanceof LumenApplication) {
+            $this->app->configure('yaml-translation');
+        }
+
+        $this->mergeConfigFrom($source, 'yaml-translation');
     }
 
     /**

--- a/src/Devitek/Core/Translation/TranslationServiceProvider.php
+++ b/src/Devitek/Core/Translation/TranslationServiceProvider.php
@@ -21,10 +21,8 @@ class TranslationServiceProvider extends \Illuminate\Translation\TranslationServ
     {
         $source = realpath(__DIR__ . '/../../../config/yaml-translation.php');
 
-        if ($this->app instanceof LaravelApplication && $this->app->runningInConsole()) {
+        if ($this->app->runningInConsole()) {
             $this->publishes([$source => config_path('yaml-translation.php')]);
-        } elseif ($this->app instanceof LumenApplication) {
-            $this->app->configure('yaml-translation');
         }
 
         $this->mergeConfigFrom($source, 'yaml-translation');

--- a/src/Devitek/Core/Translation/TranslationServiceProvider.php
+++ b/src/Devitek/Core/Translation/TranslationServiceProvider.php
@@ -6,11 +6,33 @@ use Illuminate\Translation\TranslationServiceProvider as IlluminateTranslationSe
 
 class TranslationServiceProvider extends IlluminateTranslationServiceProvider
 {
-	protected function registerLoader()
-	{
-		$this->app->singleton('translation.loader', function($app)
-		{
-			return new YamlFileLoader($app['files'], $app['path.lang']);
-		});
-	}
+    /**
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__ . '/../../../config/yaml-translation.php' => config_path('yaml-translation.php', 'yaml-translation'),
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../../../config/yaml-translation.php', 'yaml-translation'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function registerLoader()
+    {
+        $this->app->singleton('translation.loader', function ($app) {
+            return new YamlFileLoader($app[ 'files' ], $app[ 'path.lang' ]);
+        });
+    }
 }

--- a/src/Devitek/Core/Translation/YamlFileLoader.php
+++ b/src/Devitek/Core/Translation/YamlFileLoader.php
@@ -2,9 +2,9 @@
 
 namespace Devitek\Core\Translation;
 
+use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
-use Illuminate\Contracts\Translation\Loader;
 use Symfony\Component\Yaml\Parser;
 
 class YamlFileLoader implements Loader
@@ -117,7 +117,7 @@ class YamlFileLoader implements Loader
                 break;
         }
 
-        return Arr::dot($content);
+        return config('yaml-translation.dot_syntax', true) ? Arr::dot($content) : $content;
     }
 
     /**

--- a/src/Devitek/Core/Translation/YamlFileLoader.php
+++ b/src/Devitek/Core/Translation/YamlFileLoader.php
@@ -96,7 +96,7 @@ class YamlFileLoader implements Loader
     }
 
     /**
-     * require reqular php file or parse yaml before loading it
+     * Require regular php file or parse Yaml before loading it
      *
      * @param  string $extension
      * @param  string $file

--- a/src/config/yaml-translation.php
+++ b/src/config/yaml-translation.php
@@ -1,7 +1,15 @@
 <?php
 
 return [
-    // Shall this package use the array_dot schema or Laravel?
-    // If true, this will flatten all array contents into a string.
-    'dot_syntax' =>  true
+
+    /*
+    |--------------------------------------------------------------------------
+    | Array handling
+    |--------------------------------------------------------------------------
+    |
+    | Shall this package use the array_dot schema of Laravel?
+    | If true, this will flatten all array contents into a string.
+    */
+
+    'dot_syntax' => true,
 ];

--- a/src/config/yaml-translation.php
+++ b/src/config/yaml-translation.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    // Shall this package use the array_dot schema or Laravel?
+    // If true, this will flatten all array contents into a string.
+    'dot_syntax' =>  true
+];


### PR DESCRIPTION
I was not quite happy with the breaking changes in v3, because I used to create some parts (f.e. footer links) dynamically by using loops:

```
@foreach(trans('footer.links.about') as $link)
    <li>
        <a href="{{ $link['url'] }}" rel="external">
            {{ $link['name'] }}
        </a>
    </li>
@endforeach
```

Since Laravel 5.5 is out, the v2 branch cannot get installed any longer, so I had to either fork it and update the dependencies or provide a better solution, where the Arr:dot() usage is optional.  So here it is.

Oh, and last but not least: I did some minor changes to better support Laravel 5.5 and have spaces instead of tabs.